### PR TITLE
Support for Node.js 10, 12, and 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,53 +4,6 @@ notifications:
     - me@patrick.codes
 matrix:
   include:
-    - node_js: "0.8"
-    - node_js: "0.10"
-    - node_js: "0.12"
-    - node_js: "iojs"
-      env: CXX=g++-4.8
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.8
-    - node_js: "iojs"
-      compiler: clang-3.6
-      env: CXX=clang-3.6
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
-          packages:
-            - clang-3.6
-    - node_js: "4"
-      env: CXX=g++-4.8
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.8
-    - node_js: "4"
-      compiler: clang-3.6
-      env: CXX=clang-3.6
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
-          packages:
-            - clang-3.6
-    - node_js: "5"
-      env: CXX=g++-4.8
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.8
     - node_js: "8"
       env: CXX=g++-4.8
       addons:
@@ -75,7 +28,15 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.8
-    - node_js: "12"
+    - node_js: "13"
+      env: CXX=g++-4.8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+    - node_js: "13"
       compiler: clang-3.6
       env: CXX=clang-3.6
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,31 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.8
-    - node_js: "5"
+    - node_js: "8"
+      env: CXX=g++-4.8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+    - node_js: "10"
+      env: CXX=g++-4.8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+    - node_js: "12"
+      env: CXX=g++-4.8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+    - node_js: "12"
       compiler: clang-3.6
       env: CXX=clang-3.6
       addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,9 @@ environment:
   - nodejs_version: "1"
   - nodejs_version: "4"
   - nodejs_version: "5"
+  - nodejs_version: "8"
+  - nodejs_version: "10"
+  - nodejs_version: "12"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,15 +13,10 @@ notifications:
 
 environment:
   matrix:
-  - nodejs_version: "0.8"
-  - nodejs_version: "0.10"
-  - nodejs_version: "0.12"
-  - nodejs_version: "1"
-  - nodejs_version: "4"
-  - nodejs_version: "5"
-  - nodejs_version: "8"
-  - nodejs_version: "10"
-  - nodejs_version: "12"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
+    - nodejs_version: "12"
+    - nodejs_version: "13"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node-cmake": "1.x"
   },
   "devDependencies": {
-    "mocha": "1.8.x",
+    "mocha": "^6.2.2",
     "should": "1.2.x"
   },
   "dependencies": {

--- a/src/attribute.cc
+++ b/src/attribute.cc
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::Object;
-using v8::Handle;
+using v8::Context;
 using v8::HandleScope;
 using v8::Local;
 using v8::Isolate;
@@ -60,8 +60,9 @@ void Attribute::Initialize(Local<Object> exports)
   tpl->SetClassName(Nan::New("Attribute").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  exports->Set(Nan::New("Attribute").ToLocalChecked(), tpl->GetFunction());
-  constructor.Reset(tpl->GetFunction());
+  Local<Context> context = Nan::GetCurrentContext();
+  constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+  Nan::Set(exports, Nan::New("Attribute").ToLocalChecked(), tpl->GetFunction(context).ToLocalChecked());
 }
 
 Attribute::Attribute(genxAttribute attr) : attribute(attr)

--- a/src/element.cc
+++ b/src/element.cc
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::Object;
-using v8::Handle;
+using v8::Context;
 using v8::HandleScope;
 using v8::Local;
 using v8::Isolate;
@@ -58,9 +58,9 @@ void Element::Initialize(Local <Object> exports)
   tpl->SetClassName(Nan::New("Element").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  exports->Set(Nan::New("Element").ToLocalChecked(), tpl->GetFunction());
-
-  constructor.Reset(tpl->GetFunction());
+  Local<Context> context = Nan::GetCurrentContext();
+  constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+  Nan::Set(exports, Nan::New("Element").ToLocalChecked(), tpl->GetFunction(context).ToLocalChecked());
 }
 
 Element::Element(genxElement el) : element(el)

--- a/src/namespace.cc
+++ b/src/namespace.cc
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::Object;
-using v8::Handle;
+using v8::Context;
 using v8::HandleScope;
 using v8::Local;
 using v8::Isolate;
@@ -62,8 +62,9 @@ void Namespace::Initialize(Local<Object> exports)
 
   Nan::SetPrototypeMethod(tpl, "getPrefix", GetPrefix);
 
-  exports->Set(Nan::New("Namespace").ToLocalChecked(), tpl->GetFunction());
-  constructor.Reset(tpl->GetFunction());
+  Local<Context> context = Nan::GetCurrentContext();
+  constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+  Nan::Set(exports, Nan::New("Namespace").ToLocalChecked(), tpl->GetFunction(context).ToLocalChecked());
 }
 
 Namespace::Namespace(genxNamespace ns) : name_space(ns)

--- a/src/node-genx.cc
+++ b/src/node-genx.cc
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "writer.h"
 
 extern "C" {
-  static void init (v8::Handle<v8::Object> target)
+  static void init (v8::Local<v8::Object> target)
   {
     HANDLE_TO_LOCAL(target, localObj);
     Writer::Initialize(localObj);

--- a/src/writer.cc
+++ b/src/writer.cc
@@ -128,7 +128,7 @@ void Writer::New(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("First argument to Writer's constructor must be a boolean");
         return;
       }
-      prettyPrint = args[0]->ToBoolean()->Value();
+      prettyPrint = Nan::To<bool>(args[0]).FromJust();
       break;
     default:
       Nan::ThrowError("Invalid number of arguments given to Writer's constructor");
@@ -251,7 +251,7 @@ void Writer::DeclareElement(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("Second argument must be a string");
         return;
       }
-      name_space = ObjectWrap::Unwrap<Namespace>(args[0]->ToObject());
+      name_space = ObjectWrap::Unwrap<Namespace>(Nan::To<v8::Object>(args[0]).ToLocalChecked());
       Text = args[1]->ToString();
       break;
     default:
@@ -295,7 +295,7 @@ void Writer::StartElement(const Nan::FunctionCallbackInfo <Value> &args)
     return;
   }
 
-  Element *e = ObjectWrap::Unwrap<Element>(args[0]->ToObject());
+  Element *e = ObjectWrap::Unwrap<Element>(Nan::To<v8::Object>(args[0]).ToLocalChecked());
 
   w->startElement(args, e);
 }
@@ -460,7 +460,7 @@ void Writer::DeclareAttribute(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("Second argument must be a string");
         return;
       }
-      name_space = ObjectWrap::Unwrap<Namespace>(args[0]->ToObject());
+      name_space = ObjectWrap::Unwrap<Namespace>(Nan::To<v8::Object>(args[0]).ToLocalChecked());
       Text = args[1]->ToString();
       break;
     default:
@@ -508,7 +508,7 @@ void Writer::AddAttribute(const Nan::FunctionCallbackInfo <Value> &args)
     return;
   }
 
-  Attribute *attr = ObjectWrap::Unwrap<Attribute>(args[0]->ToObject());
+  Attribute *attr = ObjectWrap::Unwrap<Attribute>(Nan::To<v8::Object>(args[0]).ToLocalChecked());
   Local<String> Text = args[1]->ToString();
   value = createUtf8FromString(Text);
 

--- a/src/writer.cc
+++ b/src/writer.cc
@@ -219,7 +219,8 @@ void Writer::declareNamespace(const Nan::FunctionCallbackInfo<Value> &args, cons
 
   Local<Value> argv[1] = { GET_EXTERNAL(args.GetIsolate(), name_space) };
   Local<Function> con  = Nan::New<Function>(Namespace::constructor);
-  args.GetReturnValue().Set(con->NewInstance(1, argv));
+
+  args.GetReturnValue().Set(Nan::NewInstance(con, 1, argv).ToLocalChecked());
 }
 
 // [namespace], elementName
@@ -277,7 +278,8 @@ void Writer::declareElement(const Nan::FunctionCallbackInfo<Value> &args, genxNa
 
   Local<Value> argv[1] = { GET_EXTERNAL(args.GetIsolate(), element) };
   Local<Function> cons = Nan::New<Function>(Element::constructor);
-  args.GetReturnValue().Set(cons->NewInstance(1, argv));
+
+  args.GetReturnValue().Set(Nan::NewInstance(cons, 1, argv).ToLocalChecked());
 }
 
 void Writer::StartElement(const Nan::FunctionCallbackInfo <Value> &args)
@@ -485,7 +487,7 @@ void Writer::declareAttribute(const Nan::FunctionCallbackInfo<Value> &args, genx
 
   Local<Value> argv[1] = {GET_EXTERNAL(args.GetIsolate(), attribute) };
   Local<Function> cons = Nan::New<Function>(Attribute::constructor);
-  args.GetReturnValue().Set(cons->NewInstance(1, argv));
+  args.GetReturnValue().Set(Nan::NewInstance(cons, 1, argv).ToLocalChecked());
 }
 
 void Writer::AddAttribute(const Nan::FunctionCallbackInfo <Value> &args)

--- a/src/writer.cc
+++ b/src/writer.cc
@@ -45,7 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::Object;
-using v8::Handle;
+using v8::Context;
 using v8::HandleScope;
 using v8::Local;
 using v8::Isolate;
@@ -86,8 +86,9 @@ void Writer::Initialize(Local<Object> exports)
   Nan::SetPrototypeMethod(tpl, "endElement", EndElement);
   Nan::SetPrototypeMethod(tpl, "endElementInline", EndElementInline);
 
-  constructor.Reset(tpl->GetFunction());
-  exports->Set(Nan::New("Writer").ToLocalChecked(), tpl->GetFunction());
+  Local<Context> context = Nan::GetCurrentContext();
+  constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+  Nan::Set(exports, Nan::New("Writer").ToLocalChecked(), tpl->GetFunction(context).ToLocalChecked());
 }
 
 Writer::Writer(const bool prettyPrint, constUtf8 newLine, constUtf8 spacer)
@@ -116,13 +117,13 @@ void Writer::New(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("Third argument to Writer's constructor must be a string");
         return;
       }
-      spacer = createUtf8FromString(args[2]->ToString());
+      spacer = createUtf8FromString(Nan::To<String>(args[2]).ToLocalChecked());
     case 2:
       if(!args[1]->IsString()) {
         Nan::ThrowTypeError("Second argument to Writer's constructor must be a string");
         return;
       }
-      newLine = createUtf8FromString(args[1]->ToString());
+      newLine = createUtf8FromString(Nan::To<String>(args[1]).ToLocalChecked());
     case 1:
       if(!args[0]->IsBoolean()) {
         Nan::ThrowTypeError("First argument to Writer's constructor must be a boolean");
@@ -181,7 +182,7 @@ void Writer::DeclareNamespace(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("First argument to declareNamespace must be a string");
         return;
       }
-      Uri = args[0]->ToString();
+      Uri = Nan::To<String>(args[0]).ToLocalChecked();
       break;
     case 2:
       if (!args[0]->IsString()) {
@@ -192,8 +193,8 @@ void Writer::DeclareNamespace(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("Second argument to declareNamespace must be a string");
         return;
       }
-      Uri = args[0]->ToString();
-      Prefix = args[1]->ToString();
+      Uri = Nan::To<String>(args[0]).ToLocalChecked();
+      Prefix = Nan::To<String>(args[1]).ToLocalChecked();
       prefix = createUtf8FromString(Prefix);
       break;
     default:
@@ -240,7 +241,7 @@ void Writer::DeclareElement(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("First argument must be a string");
         return;
       }
-      Text = args[0]->ToString();
+      Text = Nan::To<String>(args[0]).ToLocalChecked();
       break;
     case 2:
       if (!args[0]->IsObject()) {
@@ -252,7 +253,7 @@ void Writer::DeclareElement(const Nan::FunctionCallbackInfo <Value> &args)
         return;
       }
       name_space = ObjectWrap::Unwrap<Namespace>(Nan::To<v8::Object>(args[0]).ToLocalChecked());
-      Text = args[1]->ToString();
+      Text = Nan::To<String>(args[1]).ToLocalChecked();
       break;
     default:
       Nan::ThrowError("Wrong number of arguments to declareElement");
@@ -329,7 +330,7 @@ void Writer::StartElementLiteral(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("First argument must be a string");
         return;
       }
-      Type = args[0]->ToString();
+      Type = Nan::To<String>(args[0]).ToLocalChecked();
       break;
     case 2:
       if (!args[0]->IsString()) {
@@ -340,9 +341,9 @@ void Writer::StartElementLiteral(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("Second argument must be a string");
         return;
       }
-      Namespace = args[0]->ToString();
+      Namespace = Nan::To<String>(args[0]).ToLocalChecked();
       name_space = createUtf8FromString(Namespace);
-      Type = args[1]->ToString();
+      Type = Nan::To<String>(args[1]).ToLocalChecked();
       break;
     default:
       Nan::ThrowError("Wrong number of arguments to startElementLiteral");
@@ -380,7 +381,7 @@ void Writer::AddText(const Nan::FunctionCallbackInfo <Value> &args)
     return;
   }
 
-  Local<String> Text = args[0]->ToString();
+  Local<String> Text = Nan::To<String>(args[0]).ToLocalChecked();
   text = createUtf8FromString(Text);
 
   w->addText(args, text);
@@ -413,7 +414,7 @@ void Writer::AddComment(const Nan::FunctionCallbackInfo <Value> &args)
     return;
   }
 
-  Local<String> Text = args[0]->ToString();
+  Local<String> Text = Nan::To<String>(args[0]).ToLocalChecked();
   text = createUtf8FromString(Text);
 
   w->addComment(args, text);
@@ -449,7 +450,7 @@ void Writer::DeclareAttribute(const Nan::FunctionCallbackInfo <Value> &args)
         Nan::ThrowTypeError("First argument must be a string");
         return;
       }
-      Text = args[0]->ToString();
+      Text = Nan::To<String>(args[0]).ToLocalChecked();
       break;
     case 2:
       if (!args[0]->IsObject()) {
@@ -461,7 +462,7 @@ void Writer::DeclareAttribute(const Nan::FunctionCallbackInfo <Value> &args)
         return;
       }
       name_space = ObjectWrap::Unwrap<Namespace>(Nan::To<v8::Object>(args[0]).ToLocalChecked());
-      Text = args[1]->ToString();
+      Text = Nan::To<String>(args[1]).ToLocalChecked();
       break;
     default:
       Nan::ThrowError("Wrong number of arguments to declareAttribute");
@@ -509,7 +510,7 @@ void Writer::AddAttribute(const Nan::FunctionCallbackInfo <Value> &args)
   }
 
   Attribute *attr = ObjectWrap::Unwrap<Attribute>(Nan::To<v8::Object>(args[0]).ToLocalChecked());
-  Local<String> Text = args[1]->ToString();
+  Local<String> Text = Nan::To<String>(args[1]).ToLocalChecked();
   value = createUtf8FromString(Text);
 
   w->addAttribute(args, attr, value);
@@ -539,8 +540,8 @@ void Writer::AddAttributeLiteral(const Nan::FunctionCallbackInfo <Value> &args)
     return;
   }
 
-  Local<String> Name = args[0]->ToString();
-  Local<String> Val = args[1]->ToString();
+  Local<String> Name = Nan::To<String>(args[0]).ToLocalChecked();
+  Local<String> Val = Nan::To<String>(args[1]).ToLocalChecked();
 
   // Get the raw UTF-8 strings
   name = createUtf8FromString(Name);
@@ -598,8 +599,19 @@ void Writer::endElementInline(const Nan::FunctionCallbackInfo<Value> &args)
   args.GetReturnValue().Set(args.This());
 }
 
-utf8 Writer::createUtf8FromString(Handle<String> String)
+utf8 Writer::createUtf8FromString(v8::Local<v8::String> String)
 {
+#if NODE_9_0_MODULE_VERSION < NODE_MODULE_VERSION
+  Local<Context> context = Nan::GetCurrentContext();
+  Isolate* isolate = context->GetIsolate();
+  utf8 string = NULL;
+  int length = String->Utf8Length(isolate) + 1;  // +1 for NUL character
+
+  string = new unsigned char[length];
+  String->WriteUtf8(isolate, (char *)string, length);
+
+  return string;
+#else
   utf8 string = NULL;
   int length = String->Utf8Length() + 1;  // +1 for NUL character
 
@@ -607,12 +619,13 @@ utf8 Writer::createUtf8FromString(Handle<String> String)
   String->WriteUtf8((char *)string, length);
 
   return string;
+#endif
 }
 
-void Writer::Emit(int argc, Handle<Value>argv[])
+void Writer::Emit(int argc, Local<Value>argv[])
 {
-  Local<Function> emit = Local<Function>::Cast(handle()->Get(Nan::New("emit").ToLocalChecked()));
-  emit->Call(handle(), argc, argv);
+  Local<Function> emit = Local<Function>::Cast(Nan::Get(handle(), Nan::New("emit").ToLocalChecked()).ToLocalChecked());
+  Nan::Call(emit, handle(), argc, argv);
 }
 
 genxStatus Writer::sender_send(void *userData, constUtf8 s)

--- a/src/writer.h
+++ b/src/writer.h
@@ -100,9 +100,9 @@ protected:
   void endElementInline(const Nan::FunctionCallbackInfo<v8::Value> &args);
 
 private:
-  static utf8 createUtf8FromString(v8::Handle<v8::String> String);
+  static utf8 createUtf8FromString(v8::Local<v8::String> String);
 
-  void Emit(int argc, v8::Handle<v8::Value>argv[]);
+  void Emit(int argc, v8::Local<v8::Value>argv[]);
   static genxStatus sender_send(void *userData, constUtf8 s);
   static genxStatus sender_sendBounded(void *userData, constUtf8 start, constUtf8 end);
   static genxStatus sender_flush(void * userData);


### PR DESCRIPTION
We are trying to upgrade a few older apps which rely on this module, and we were unable to get it to compile on node versions newer than node 8.

I tried to make as small and focused commits as possible, but it got a bit out of hand when I tackled node 12.

The most recent version of nan drops support for node older than 8, so I removed them from CI as well. I updated mocha, as npm was warning about security issues (no changes in the API).

I hope that you can excuse the batching up of changes in this PR. Feel free to cherry-pick instead if that is easier to manage.